### PR TITLE
Fixed issue with keymap case sensitivity

### DIFF
--- a/app/config/keymaps.js
+++ b/app/config/keymaps.js
@@ -5,6 +5,22 @@ const _paths = require('./paths');
 const commands = {};
 const keys = {};
 
+const _setKeysForCommands = function (keyMap) {
+  for (const command in keyMap) {
+    if (command) {
+      commands[command] = keyMap[command].toLowerCase();
+    }
+  }
+};
+
+const _setCommandsForKeys = function (commands) {
+  for (const command in commands) {
+    if (command) {
+      keys[commands[command]] = command;
+    }
+  }
+};
+
 const _import = function (customsKeys) {
   const path = () => {
     switch (process.platform) {
@@ -15,26 +31,13 @@ const _import = function (customsKeys) {
     }
   };
   try {
-    const cmds = JSON.parse(readFileSync(path()));
-    for (const command in cmds) {
-      if (command) {
-        commands[command] = cmds[command];
-        keys[commands[command]] = command;
-      }
-    }
-
-    if (customsKeys) {
-      for (const command in customsKeys) {
-        if (command) {
-          commands[command] = customsKeys[command];
-          keys[customsKeys[command]] = command;
-        }
-      }
-    }
+    const keyMap = JSON.parse(readFileSync(path()));
+    _setKeysForCommands(keyMap);
+    _setKeysForCommands(customsKeys);
+    _setCommandsForKeys(commands);
 
     return {commands, keys};
-  } catch (err) {
-  }
+  } catch (err) {}
 };
 
 const _extend = function (customsKeys) {

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -7,10 +7,10 @@
  "zoom:in":"ctrl+plus",
  "zoom:out":"ctrl+-",
  "window:new":"ctrl+shift+n",
- "window:minimize": "ctrl+M",
+ "window:minimize": "ctrl+m",
  "window:full": "f11",
  "window:close":"ctrl+shift+w",
- 
+
  "tab:new":"ctrl+shift+t",
  "tab:next":"ctrl+tab",
  "tab:prev":"ctrl+shift+tab",
@@ -19,7 +19,7 @@
  "pane:vertical":"ctrl+shift+d",
  "pane:horizontal":"ctrl+shift+e",
  "pane:close":"ctrl+shift+w",
- 
+
  "editor:undo":"ctrl+shift+z",
  "editor:redo":"ctrl+shift+y",
  "editor:cut":"ctrl+shift+x",
@@ -27,6 +27,6 @@
  "editor:paste":"ctrl+shift+v",
  "editor:selectAll":"ctrl+shift+a",
  "editor:clearBuffer":"ctrl+shift+k",
- 
+
  "plugins:update": "ctrl+shift+u"
 }


### PR DESCRIPTION
Keymaps used to be case sensitive, leading to a small
handful of bugs (minimization in windows), and making custom
key mapping more difficult.

see https://github.com/zeit/hyper/pull/1509